### PR TITLE
Fix code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Quick and Dirty Example
    //To serialize an object with a limited depth recursion (aka only some of it)
    $jsonData = 
       BDBStudios\BreakfastSerializer\SerializerFactory::getSerializer(
-         IsSerializable::FORMAT_JSON,
+         BDBStudios\BreakfastSerializer\IsSerializable::FORMAT_JSON,
          2
       )
       ->serialize($myClass);


### PR DESCRIPTION
Since there is no `use` in the example, I put the full namespaced class name for the constant.

Also I restrained myself from trimming all those spaces at the end of the lines :grin: 